### PR TITLE
Add modules to blacklist in README.md + simpler dkms.conf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ KVER ?= $(if $(KERNELRELEASE),$(KERNELRELEASE),$(shell uname -r))
 KSRC ?= $(if $(KERNEL_SRC),$(KERNEL_SRC),/lib/modules/$(KVER)/build)
 FWDIR := /lib/firmware/mediatek
 JOBS ?= $(shell nproc --ignore=1)
-MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/bluetooth
+MODNAME := btusb_mt7902
+MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/bluetooth/$(MODNAME)
 
 ifneq ("$(INSTALL_MOD_PATH)", "")
 DEPMOD_ARGS = -b $(INSTALL_MOD_PATH)
@@ -28,14 +29,14 @@ SRC_DIR := $(shell pwd)/src
 
 all:
 	$(MAKE) -j$(JOBS) -C $(KSRC) M=$(SRC_DIR) modules
-	@cp $(SRC_DIR)/*.ko .
+	@cp -v $(SRC_DIR)/*.ko .
 
 clean:
 	$(MAKE) -j$(JOBS) -C $(KSRC) M=$(SRC_DIR) clean
-	@rm -f *.ko
+	@rm -vf *.ko
 
 install: all
-	@install -D -m 644 -t $(MODDESTDIR) *.ko
+	@install -vDm 644 -t $(MODDESTDIR) *.ko
 ifeq ($(COMPRESS_GZIP), y)
 	@gzip -f $(MODDESTDIR)/*.ko
 endif
@@ -49,9 +50,9 @@ endif
 
 install_fw:
 ifeq ($(wildcard $(FWDIR)), )
-	@install -Dvm 644 -t $(FWDIR) firmware/*.bin
+	@install -vDm 644 -t $(FWDIR) firmware/*.bin
 else
-	@cp -r firmware tmp
+	@cp -vr firmware tmp
 ifneq ($(wildcard $(FWDIR)/*.zst), )
 	@zstd -fq --rm tmp/*.bin
 endif
@@ -61,11 +62,12 @@ endif
 ifneq ($(wildcard $(FWDIR)/*.gz), )
 	@gzip -f tmp/*.bin
 endif
-	@install -Dvm 644 -t $(FWDIR) tmp/*
-	@rm -rf tmp
+	@install -vDm 644 -t $(FWDIR) tmp/*
+	@rm -vrf tmp
 endif
 
 uninstall:
-	@rmmod -s btusb_mt7902 || true
-	@rm -rf $(MODDESTDIR)
+	@echo "Unloading module"
+	@rmmod -v $(MODNAME) || true
+	@rm -vrf $(MODDESTDIR)
 	@depmod $(DEPMOD_ARGS)

--- a/README.md
+++ b/README.md
@@ -31,19 +31,34 @@ cd btusb_mt7902
 make -j$(nproc)
 ```
 
-- To build the driver & install it, use this command
+- To build the driver & install it:
 
 ```bash
 sudo make install -j$(nproc)
 ```
 
-- To install the firmware required for the driver, use this command
+- To install the firmware required for the driver:
 
 ```bash
 sudo make install_fw
 ```
 
+- To remove the driver:
+
+```bash
+sudo make uninstall
+```
+
 Once you got the driver & firmware installed, reboot to see changes.
+
+## Note
+
+`btusb` and `btmtk` conflict with `btusb_mt7902`, unload them if loading `btusb_mt7902` presents an error.
+
+You can blacklist them by putting this in `/etc/modprobe.d/blacklist_btusb.conf`:
+```
+blacklist btusb btmtk
+```
 
 ## Feedback
 

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,18 +1,6 @@
 PACKAGE_NAME="btusb_mt7902"
-# We will use "git" here. If you want the actual hash, see the Makefile trick below.
-PACKAGE_VERSION="git" 
-
-# DKMS sets $kernelver, so we pass it to your Makefile using KVER
+PACKAGE_VERSION="git"
 MAKE[0]="make KVER=$kernelver"
-CLEAN="make clean"
-
-BUILT_MODULE_NAME[0]="btusb_mt7902"
-# DKMS expects the module to be where the make command finishes. 
-# Since your Makefile copies it to the root dir, we use "."
-BUILT_MODULE_LOCATION[0]="."
-
-# The destination inside /lib/modules/$(uname -r)/...
-DEST_MODULE_LOCATION[0]="/kernel/drivers/bluetooth"
-
-# Rebuild automatically on kernel updates
+BUILT_MODULE_NAME[0]=$PACKAGE_NAME
+DEST_MODULE_LOCATION[0]="/kernel/drivers/bluetooth/$PACKAGE_NAME"
 AUTOINSTALL="yes"


### PR DESCRIPTION
`BUILT_MODULE_NAME` now follows `PACKAGE_NAME`, so you need only edit the latter to reflect changes in the former.

I also suggest changing `DEST_MODULE_LOCATION[0]` to `/kernel/drivers/bluetooth/btusb_mt7902` to give it a unique location.