### PR TITLE
Simpler dkms.conf, add verboseness to Makefile, add uninstall to README.md + add uninstall_fw command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ KVER ?= $(if $(KERNELRELEASE),$(KERNELRELEASE),$(shell uname -r))
 KSRC ?= $(if $(KERNEL_SRC),$(KERNEL_SRC),/lib/modules/$(KVER)/build)
 FWDIR := /lib/firmware/mediatek
 JOBS ?= $(shell nproc --ignore=1)
-MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/mediatek/mt7902e
+MODNAME := mt7902e
+MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/mediatek/$(MODNAME)
 MT76DIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/mediatek/mt76
 
 ifneq ("$(INSTALL_MOD_PATH)", "")
@@ -29,14 +30,14 @@ SRC_DIR := $(shell pwd)/src
 
 all:
 	$(MAKE) -j$(JOBS) -C $(KSRC) M=$(SRC_DIR) modules
-	@cp $(SRC_DIR)/*.ko .
+	@cp -v $(SRC_DIR)/*.ko .
 
 clean:
 	$(MAKE) -j$(JOBS) -C $(KSRC) M=$(SRC_DIR) clean
-	@rm -f *.ko
+	@rm -vf *.ko
 
 install: all
-	@install -D -m 644 -t $(MODDESTDIR) *.ko
+	@install -vDm 644 -t $(MODDESTDIR) *.ko
 ifeq ($(COMPRESS_GZIP), y)
 	@gzip -f $(MODDESTDIR)/*.ko
 endif
@@ -50,9 +51,9 @@ endif
 
 install_fw:
 ifeq ($(wildcard $(FWDIR)), )
-	@install -Dvm 644 -t $(FWDIR) firmware/*.bin
+	@install -vDm 644 -t $(FWDIR) firmware/*.bin
 else
-	@cp -r firmware tmp
+	@cp -vr firmware tmp
 ifneq ($(wildcard $(FWDIR)/*.zst), )
 	@zstd -fq --rm tmp/*.bin
 endif
@@ -62,11 +63,12 @@ endif
 ifneq ($(wildcard $(FWDIR)/*.gz), )
 	@gzip -f tmp/*.bin
 endif
-	@install -Dvm 644 -t $(FWDIR) tmp/*
-	@rm -rf tmp
+	@install -vDm 644 -t $(FWDIR) tmp/*
+	@rm -vrf tmp
 endif
 
 uninstall:
-	@rmmod -s mt7902e || true
-	@rm -rf $(MODDESTDIR)
+	@echo "Unloading module"
+	@rmmod -v $(MODNAME) || true
+	@rm -vrf $(MODDESTDIR)
 	@depmod $(DEPMOD_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ endif
 
 install_fw:
 ifeq ($(wildcard $(FWDIR)), )
-	@install -vDm 644 -t $(FWDIR) firmware/*.bin
+	@install -vDm 644 -t $(FWDIR)/$(MODNAME) firmware/*.bin
 else
 	@cp -vr firmware tmp
 ifneq ($(wildcard $(FWDIR)/*.zst), )
@@ -63,7 +63,7 @@ endif
 ifneq ($(wildcard $(FWDIR)/*.gz), )
 	@gzip -f tmp/*.bin
 endif
-	@install -vDm 644 -t $(FWDIR) tmp/*
+	@install -vDm 644 -t $(FWDIR)/$(MODNAME) tmp/*
 	@rm -vrf tmp
 endif
 
@@ -72,3 +72,6 @@ uninstall:
 	@rmmod -v $(MODNAME) || true
 	@rm -vrf $(MODDESTDIR)
 	@depmod $(DEPMOD_ARGS)
+
+uninstall_fw:
+	@rm -vrf $(FWDIR)/$(MODNAME)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ make -j$(nproc)
 sudo make install -j$(nproc)
 ```
 
+> [!TIP]
+> As per the [20260309](https://gitlab.com/kernel-firmware/linux-firmware#linux-firmware) release, the firmware should be already provided by your distribution, for Debian as of present, check in the unstable repo.
+
 - To install the firmware required for the driver:
 
 ```bash
@@ -47,6 +50,12 @@ sudo make install_fw
 
 ```bash
 sudo make uninstall
+```
+
+- To remove the firmware:
+
+```bash
+sudo make uninstall_fw
 ```
 
 Once you got the driver & firmware installed, reboot to see changes.

--- a/README.md
+++ b/README.md
@@ -31,16 +31,22 @@ cd mt7902
 make -j$(nproc)
 ```
 
-- To build the driver & install it, use this command
+- To build the driver & install it:
 
 ```bash
 sudo make install -j$(nproc)
 ```
 
-- To install the firmware required for the driver, use this command
+- To install the firmware required for the driver:
 
 ```bash
 sudo make install_fw
+```
+
+- To remove the driver:
+
+```bash
+sudo make uninstall
 ```
 
 Once you got the driver & firmware installed, reboot to see changes.

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,18 +1,6 @@
 PACKAGE_NAME="mt7902e"
-# We will use "git" here. If you want the actual hash, see the Makefile trick below.
-PACKAGE_VERSION="git" 
-
-# DKMS sets $kernelver, so we pass it to your Makefile using KVER
+PACKAGE_VERSION="git"
 MAKE[0]="make KVER=$kernelver"
-CLEAN="make clean"
-
-BUILT_MODULE_NAME[0]="mt7902e"
-# DKMS expects the module to be where the make command finishes. 
-# Since your Makefile copies it to the root dir, we use "."
-BUILT_MODULE_LOCATION[0]="."
-
-# The destination inside /lib/modules/$(uname -r)/...
-DEST_MODULE_LOCATION[0]="/kernel/drivers/net/wireless/mediatek/mt7902e"
-
-# Rebuild automatically on kernel updates
+BUILT_MODULE_NAME[0]=$PACKAGE_NAME
+DEST_MODULE_LOCATION[0]="/kernel/drivers/net/wireless/mediatek/$PACKAGE_NAME"
 AUTOINSTALL="yes"


### PR DESCRIPTION
Same as the one done for `bluetooth_backport`