### PR TITLE
docs: add community automated installer as alternative install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,23 @@ sudo make uninstall_fw
 
 Once you got the driver & firmware installed, reboot to see changes.
 
+> [!TIP]
+> ### Automated installation
+> 
+> Community installer that handles the entire process automatically (distro detection, dependencies, compilation, blacklisting, DKMS, initramfs):
+> 
+> ```bash
+> curl -sSL https://raw.githubusercontent.com/EdinsonMoreno/mt7902-linux-installer/main/install.sh | sudo bash
+> ```
+> 
+> Also includes automated uninstall:
+> ```bash
+> curl -sSL https://raw.githubusercontent.com/EdinsonMoreno/mt7902-linux-installer/main/uninstall.sh | sudo bash
+> ```
+> 
+> Supports Fedora, RHEL, Ubuntu/Debian, Arch Linux.
+> Full repo: [EdinsonMoreno/mt7902-linux-installer](https://github.com/EdinsonMoreno/mt7902-linux-installer)
+
 ## Feedback
 
 If you have any issue using this driver, please provide feedback in this [Discord group](https://discord.gg/JGhjAxEFhz).


### PR DESCRIPTION
### Summary

Adds an optional automated installation method to the README. The installer handles:

- Distro detection (Fedora, RHEL, Ubuntu/Debian, Arch)
- Build dependency installation
- Driver compilation & installation
- In-tree module blacklisting (necessary to avoid symbol conflicts)
- DKMS registration (survives kernel updates)
- Initramfs rebuild
- Automated uninstall too

### Why

Many users struggle with manual compilation — especially around blacklisting conflicting in-tree modules, DKMS setup, and initramfs rebuild. The `curl | bash` approach gives them a zero-friction option.

Repo: https://github.com/EdinsonMoreno/mt7902-linux-installer

Feel free to modify or reject.