### PR TITLE
fix: use __netmem_get_pp for kernel >= 6.17 in mt76_put_page_pool_buf

### DIFF
--- a/src/mt76.h
+++ b/src/mt76.h
@@ -1879,6 +1879,8 @@ static inline void mt76_put_page_pool_buf(void *buf, bool allow_direct)
 	struct page *page = virt_to_head_page(buf);
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0))
+	page_pool_put_full_page(__netmem_get_pp(page_to_netmem(page)), page,
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0))
 	page_pool_put_full_page(pp_page_to_nmdesc(page)->pp, page,
 #else
 	page_pool_put_full_page(page->pp, page,


### PR DESCRIPTION
pp_page_to_nmdesc() was introduced in kernel 6.13 as part of the netmem abstraction and removed in 6.17 in favour of __netmem_get_pp() + page_to_netmem().  The previous guard branched on >= 6.17 to use pp_page_to_nmdesc(), which is the exact version that removed the function, causing a build failure on 6.17+.

Replace the two-way guard with a three-way guard:
  >= 6.17 : __netmem_get_pp(page_to_netmem(page))   [new API]
  >= 6.13 : pp_page_to_nmdesc(page)->pp              [transitional API]
  < 6.13  : page->pp                                 [original field]

Tested: builds and loads on Ubuntu kernel 6.17.0-23-generic (MT7902 ASIC rev 79020000, firmware loaded, wlp2s0 interface up).