### PR TITLE
mt76: fix mt76_get_txpower() returning 0 dBm on systems with invalid ACPI SAR data

### DIFF
--- a/src/mac80211.c
+++ b/src/mac80211.c
@@ -1782,12 +1782,25 @@ int mt76_get_txpower(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 	struct mt76_phy *phy = mt76_vif_phy(hw, vif);
 	int n_chains, delta;
 
+	/* Fall back to the primary phy when vif context isn't set yet */
+	if (!phy)
+		phy = hw->priv;
+
 	if (!phy)
 		return -EINVAL;
 
 	n_chains = hweight16(phy->chainmask);
 	delta = mt76_tx_power_path_delta(n_chains);
-	*dbm = DIV_ROUND_UP(phy->txpower_cur + delta, 2);
+
+	if (phy->txpower_cur <= 0 && phy->chandef.chan) {
+		/* txpower_cur not yet set by firmware; fall back to the
+		 * regulatory max for this channel. mt76_get_sar_power can
+		 * return garbage values on systems with invalid ACPI SAR
+		 * tables (e.g. frp[i].power == -1), so we bypass it here. */
+		*dbm = phy->chandef.chan->max_power;
+	} else {
+		*dbm = DIV_ROUND_UP(phy->txpower_cur + delta, 2);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
## Problem

On systems where the ACPI table exposes a SAR node but populates it with invalid values (e.g. `frp[i].power == -1`), `mt76_get_sar_power()` caps TX power at -1 (in 0.5 dBm units = -0.5 dBm). This makes `DIV_ROUND_UP(-1, 2) == 0`, so `mt76_get_txpower()` always returns 0 dBm regardless of the actual channel.

The symptom is visible via `iw dev wlo1 info` reporting `txpower 0.00 dBm` even when connected and transmitting normally.

## Root cause

`mt76_get_txpower()` calls `mt76_get_power_bound()` which internally calls `mt76_get_sar_power()`. When `phy->frp` is set from ACPI data containing invalid power limits, `min_t(int, frp[i].power, power)` = `min(-1, 40)` = `-1`, poisoning the result.

## Fix

When `txpower_cur <= 0` (not yet initialized by firmware), fall back directly to `chan->max_power` (the regulatory limit for the channel) instead of going through `mt76_get_power_bound()`. This bypasses the ACPI SAR path entirely for the fallback case.

Additionally adds a NULL guard in `mt76_get_txpower()` for when `mt76_vif_phy()` returns NULL before the vif context is set — consistent with the existing `>= 6.15` behavior.

## Tested on

- CPU: Intel i5-1235U
- Hardware: MT7902 (PCI `14c3:7902`)
- Kernel: 7.0.9 (Fedora 44)
- Regulatory domain: CO (Colombia) — channel 1, 2.4 GHz

Before fix: `txpower 0.00 dBm`
After fix: `txpower 20.00 dBm` ✅

## Debug trace confirming root cause

```
mt76_get_txpower: txpower_cur=-1 chan=1 max_power=20 tx_power=-1 delta=0 dbm=0
```

`tx_power=-1` is the value returned by `mt76_get_power_bound()` — confirmed that `mt76_get_sar_power()` was applying `frp[i].power == -1` from the ACPI table.