### PR TITLE
mt76: mt76_vif_phy() return hw->priv when chanctx is absent

### DIFF
--- a/src/mac80211.c
+++ b/src/mac80211.c
@@ -870,7 +870,7 @@ struct mt76_phy *mt76_vif_phy(struct ieee80211_hw *hw,
 #endif
 
 	if (!mlink->ctx)
-		return NULL;
+		return hw->priv;
 
 	ctx = (struct mt76_chanctx *)mlink->ctx->drv_priv;
 	return ctx->phy;


### PR DESCRIPTION
## Problem

On single-radio setups or during early STA association events, `mlink->ctx` may not be assigned yet. `mt76_vif_phy()` currently returns `NULL` in this case, which propagates as `-EINVAL` (-22) to any caller that doesn't explicitly guard against NULL, causing station insertion to fail:

```
wlp3s0: failed to insert STA entry for the AP (error -22)
```

Reported by @oswystk15662 in issue #11: https://github.com/hmtheboy154/mt7902/issues/11#issuecomment-4488861026

## Fix

Return `hw->priv` (the primary PHY) instead of `NULL` when `mlink->ctx == NULL`. This matches the behavior already implemented for kernels >= 6.15 with `!hw->wiphy->n_radio`:

```c
#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0))
    if (!hw->wiphy->n_radio)
        return hw->priv;
#endif
```

The same logic applies here: on a single-radio device with no chanctx assigned yet, `hw->priv` is always the correct PHY to return.

## Tested on

- Hardware: MT7902 (PCI `14c3:7902`)
- Kernel: 7.0.9 (Fedora 44)
- WiFi association completes successfully after this fix

## Note

This fix was verified independently by @oswystk15662 (Ubuntu 22.04, kernel 6.8.0) as resolving the `-22` error on their setup.