### PR TITLE
btusb: add MediaTek generic USB ID 0e8d:7902 to quirks_table

### DIFF
--- a/src/btusb.c
+++ b/src/btusb.c
@@ -194,6 +194,8 @@ static const struct usb_device_id quirks_table[] = {
 						     BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x13d3, 0x3596), .driver_info = BTUSB_MEDIATEK |
 						     BTUSB_WIDEBAND_SPEECH },
+	{ USB_DEVICE(0x0e8d, 0x7902), .driver_info = BTUSB_MEDIATEK |
+						     BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x0e8d, 0x1ede), .driver_info = BTUSB_MEDIATEK |
 						     BTUSB_WIDEBAND_SPEECH },
 


### PR DESCRIPTION
## Problem

MT7902 modules that use MediaTek's **generic USB ID `0e8d:7902`** (instead of an OEM-specific `13d3:xxxx` ID) bind to `btusb_mt7902` without the `BTUSB_MEDIATEK` flag, because `quirks_table` doesn't list that ID and this stripped-down driver no longer carries mainline's generic catch-all entry (`USB_VENDOR_AND_INTERFACE_INFO(0x0e8d, 0xe0, 0x01, 0x01)`).

As a result `hdev->setup` is never wired to the MediaTek setup path, no firmware is downloaded, and the controller stays completely mute:

```
Bluetooth: hci0: Opcode 0x0c03 failed: -110
```

`hciconfig` shows `BD Address: 00:00:00:00:00:00`, 0 RX bytes, and the adapter never comes up.

This affects at least the Minisforum UM870 Slim (and likely other mini PCs that ship MediaTek-branded MT7902 modules rather than AzureWave/IMC ones):

```
Bus 001 Device 006: ID 0e8d:7902 MediaTek Inc. Wireless_Device
```

## Fix

Add `0e8d:7902` to `quirks_table` with `BTUSB_MEDIATEK | BTUSB_WIDEBAND_SPEECH`, next to the existing `0e8d:1ede` entry.

## Tested

Minisforum UM870 Slim (Ryzen 7 8745H), Ubuntu 22.04.5, kernel 6.8.0-134-generic (HWE), built via DKMS. With this change the firmware downloads on probe and the controller works fully (pairing, HID, audio):

```
Bluetooth: hci0: HW/SW Version: 0x008a008a, Build Time: 20250826211444
Bluetooth: hci0: Device setup in 2769305 usecs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
