### PR TITLE
mt76: fix association failure on kernels without wiphy->n_radio

### DIFF
--- a/src/mac80211.c
+++ b/src/mac80211.c
@@ -861,19 +861,21 @@ EXPORT_SYMBOL_GPL(mt76_reset_device);
 struct mt76_phy *mt76_vif_phy(struct ieee80211_hw *hw,
 			      struct ieee80211_vif *vif)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0))
 	struct mt76_vif_link *mlink = (struct mt76_vif_link *)vif->drv_priv;
 	struct mt76_chanctx *ctx;
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0))
 	if (!hw->wiphy->n_radio)
 		return hw->priv;
-#endif
 
 	if (!mlink->ctx)
 		return NULL;
 
 	ctx = (struct mt76_chanctx *)mlink->ctx->drv_priv;
 	return ctx->phy;
+#else
+	return hw->priv;
+#endif
 }
 EXPORT_SYMBOL_GPL(mt76_vif_phy);
 


### PR DESCRIPTION
Commit fe503c3b294c ("mt7902e: Backport down to 6.6") wrapped the n_radio == 0 fast path in mt76_vif_phy() in a version guard, because wiphy->n_radio does not exist on older kernels. The guard removed the fast path instead of preserving its behaviour, so on any kernel below the guarded version mt76_vif_phy() falls through to the chanctx lookup.

That lookup is never valid for mt792x. The MT7902 firmware does not advertise MT792x_FW_CAP_CNM, so mt792x_get_mac80211_ops() clears ops->assign_vif_chanctx and mlink->ctx stays NULL forever. mt76_vif_phy() therefore returns NULL, mt76_sta_state() bails out with -EINVAL, and every association attempt fails with:

  wlan0: failed to insert STA entry for the AP (error -22)

mt76_get_txpower() is broken by the same path and stops reporting TX power.

Even with a CNM-capable firmware the fall-through would be wrong: mt792x sets hw->chanctx_data_size to sizeof(struct mt792x_chanctx), whose first member is a struct mt792x_bss_conf pointer, so the struct mt76_chanctx cast would be a type confusion.

This driver never registers more than one radio, so the n_radio == 0 fast path always applies. Return hw->priv unconditionally on kernels lacking wiphy->n_radio, mirroring the #else pattern already used for mt76_get_survey() in the same commit.

Tested on 6.12.100+deb13-amd64: association completes and the link reaches HE-MCS 11 rates.

Fixes: fe503c3b294c ("mt7902e: Backport down to 6.6")