### PR TITLE
mt7902: disable TX A-MPDU aggregation by default

### DIFF
--- a/src/mac80211.c
+++ b/src/mac80211.c
@@ -340,6 +340,10 @@ mt76_init_sband(struct mt76_phy *phy, struct mt76_sband *msband,
 		       IEEE80211_HT_CAP_SGI_40 |
 		       (1 << IEEE80211_HT_CAP_RX_STBC_SHIFT);
 
+	if (msband == &phy->sband_2g && phy->cap.no_ht40_2ghz)
+		ht_cap->cap &= ~(IEEE80211_HT_CAP_SUP_WIDTH_20_40 |
+				 IEEE80211_HT_CAP_SGI_40);
+
 	ht_cap->mcs.tx_params = IEEE80211_HT_MCS_TX_DEFINED;
 	ht_cap->ampdu_factor = IEEE80211_HT_MAX_AMPDU_64K;
 

--- a/src/mt76.h
+++ b/src/mt76.h
@@ -516,6 +516,7 @@ struct mt76_hw_cap {
 	bool has_2ghz;
 	bool has_5ghz;
 	bool has_6ghz;
+	bool no_ht40_2ghz;
 };
 
 #define MT_DRV_TXWI_NO_FREE		BIT(0)

--- a/src/mt7902/init.c
+++ b/src/mt7902/init.c
@@ -325,6 +325,7 @@ int mt7921_register_device(struct mt792x_dev *dev)
 		return ret;
 
 	hw->wiphy->reg_notifier = mt7921_regd_notifier;
+	dev->mphy.cap.no_ht40_2ghz = mt7921_ht40_2g_blocked(&dev->phy);
 	dev->mphy.sband_2g.sband.ht_cap.cap |=
 			IEEE80211_HT_CAP_LDPC_CODING |
 			IEEE80211_HT_CAP_MAX_AMSDU;

--- a/src/mt7902/main.c
+++ b/src/mt7902/main.c
@@ -9,6 +9,16 @@
 #include "mt7921.h"
 #include "mcu.h"
 
+/* MT7902 firmware neither negotiates ADDBA autonomously (as MT7921 fw does
+ * with IEEE80211_AMPDU_TX_START_IMMEDIATE) nor tolerates a mac80211-driven
+ * BlockAck handshake: with aggregation enabled >80% of TX MPDUs fail and
+ * >50% of A-MPDUs receive no BlockAck (ba_miss), collapsing the link.
+ * Default TX A-MPDU aggregation off; RX aggregation is unaffected.
+ */
+static bool mt7921_disable_tx_aggr = true;
+module_param_named(disable_tx_aggr, mt7921_disable_tx_aggr, bool, 0644);
+MODULE_PARM_DESC(disable_tx_aggr, "disable TX A-MPDU aggregation (default: on for MT7902)");
+
 static int
 mt7921_init_he_caps(struct mt792x_phy *phy, enum nl80211_band band,
 		    struct ieee80211_sband_iftype_data *data)
@@ -1005,6 +1015,10 @@ mt7921_ampdu_action(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 		mt7921_mcu_uni_tx_ba(dev, params, false);
 		break;
 	case IEEE80211_AMPDU_TX_START:
+		if (mt7921_disable_tx_aggr) {
+			ret = -EOPNOTSUPP;
+			break;
+		}
 		set_bit(tid, &msta->deflink.wcid.ampdu_state);
 		ret = IEEE80211_AMPDU_TX_START_IMMEDIATE;
 		break;

--- a/src/mt7902/main.c
+++ b/src/mt7902/main.c
@@ -19,6 +19,22 @@ static bool mt7921_disable_tx_aggr = true;
 module_param_named(disable_tx_aggr, mt7921_disable_tx_aggr, bool, 0644);
 MODULE_PARM_DESC(disable_tx_aggr, "disable TX A-MPDU aggregation (default: on for MT7902)");
 
+/* MT7902 does not pass traffic on a 40 MHz channel in the 2.4 GHz band even
+ * though the firmware accepts CHANNEL_SWITCH / BSS_INFO_RLM with CBW_40MHZ:
+ * no HE data is decoded from the AP and nothing we transmit is acked, while
+ * the same link at 20 MHz (and 5 GHz at 80 MHz) is fine.  Only advertise
+ * 20 MHz on 2.4 GHz so mac80211 never negotiates HT40/HE40 there.
+ */
+static bool mt7921_disable_ht40_2g = true;
+module_param_named(disable_ht40_2g, mt7921_disable_ht40_2g, bool, 0444);
+MODULE_PARM_DESC(disable_ht40_2g, "do not advertise 40 MHz on 2.4 GHz (default: on for MT7902)");
+
+bool mt7921_ht40_2g_blocked(struct mt792x_phy *phy)
+{
+	return mt7921_disable_ht40_2g && is_mt7902(phy->mt76->dev);
+}
+EXPORT_SYMBOL_GPL(mt7921_ht40_2g_blocked);
+
 static int
 mt7921_init_he_caps(struct mt792x_phy *phy, enum nl80211_band band,
 		    struct ieee80211_sband_iftype_data *data)
@@ -62,6 +78,7 @@ mt7921_init_he_caps(struct mt792x_phy *phy, enum nl80211_band band,
 
 		if (band == NL80211_BAND_2GHZ)
 			he_cap_elem->phy_cap_info[0] =
+				mt7921_ht40_2g_blocked(phy) ? 0 :
 				IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_40MHZ_IN_2G;
 		else
 			he_cap_elem->phy_cap_info[0] =
@@ -132,8 +149,11 @@ mt7921_init_he_caps(struct mt792x_phy *phy, enum nl80211_band band,
 				IEEE80211_HE_PHY_CAP7_POWER_BOOST_FACTOR_SUPP |
 				IEEE80211_HE_PHY_CAP7_HE_SU_MU_PPDU_4XLTF_AND_08_US_GI;
 			he_cap_elem->phy_cap_info[8] |=
-				IEEE80211_HE_PHY_CAP8_20MHZ_IN_40MHZ_HE_PPDU_IN_2G |
 				IEEE80211_HE_PHY_CAP8_DCM_MAX_RU_484;
+			if (band != NL80211_BAND_2GHZ ||
+			    !mt7921_ht40_2g_blocked(phy))
+				he_cap_elem->phy_cap_info[8] |=
+					IEEE80211_HE_PHY_CAP8_20MHZ_IN_40MHZ_HE_PPDU_IN_2G;
 			he_cap_elem->phy_cap_info[9] |=
 				IEEE80211_HE_PHY_CAP9_LONGER_THAN_16_SIGB_OFDM_SYM |
 				IEEE80211_HE_PHY_CAP9_NON_TRIGGERED_CQI_FEEDBACK |

--- a/src/mt7902/mt7921.h
+++ b/src/mt7902/mt7921.h
@@ -280,6 +280,7 @@ void mt7921_queue_rx_skb(struct mt76_dev *mdev, enum mt76_rxq_id q,
 			 struct sk_buff *skb, u32 *info);
 void mt7921_stats_work(struct work_struct *work);
 void mt7921_set_stream_he_caps(struct mt792x_phy *phy);
+bool mt7921_ht40_2g_blocked(struct mt792x_phy *phy);
 int mt7921_init_debugfs(struct mt792x_dev *dev);
 
 int mt7921_mcu_set_beacon_filter(struct mt792x_dev *dev,


### PR DESCRIPTION
MT7902 firmware does not negotiate ADDBA with the peer, despite the driver returning IEEE80211_AMPDU_TX_START_IMMEDIATE from mt7921_ampdu_action() (a contract inherited from MT7921, whose firmware does perform the handshake autonomously).

The result is that A-MPDUs are transmitted to an AP that never agreed to a BlockAck session, so the aggregates are discarded and never acked. Observed on MT7902 (14c3:7902) against a TP-Link XDR5430, kernel 6.18.9, on both bands and at good signal (-56..-66 dBm, zero beacon loss):

  tx_ampdu_cnt:      14449
  tx_mpdu_attempts:  15670
  tx_mpdu_success:    2778   (17.7%)
  ba_miss_count:      7580   (52% of A-MPDUs unacked)

  60s ICMP to the gateway: 40-67% packet loss, RTT avg 116 ms / max 2.6 s
  rate control collapses to 6 Mbit/s

Letting mac80211 drive the handshake instead (returning 0 rather than START_IMMEDIATE) is worse: TX stops entirely (100% loss).

Disabling TX aggregation restores the link completely:

  tx failed:      0
  ba_miss_count:  0
  60s ICMP: 0% loss, RTT avg 4.2 ms (2.4 GHz) / 4-6 ms (5 GHz)

RX aggregation is untouched, so downlink throughput is unaffected (288 Mbit/s RX HE-MCS 5 still negotiated).

A module parameter is provided for users whose firmware revision may behave differently:

  modprobe mt7902e disable_tx_aggr=0

Note: the fix is done by Claude Fable. 